### PR TITLE
fix: error handling

### DIFF
--- a/android/src/main/java/com/reactnativepiwikprosdk/PiwikProSdkModule.kt
+++ b/android/src/main/java/com/reactnativepiwikprosdk/PiwikProSdkModule.kt
@@ -55,7 +55,7 @@ class PiwikProSdkModule(reactContext: ReactApplicationContext) : ReactContextBas
         try {
             TrackHelper.track()
                 .screen(path)
-                .with(this.tracker ?: throw Error("Tracker is not initialized"))
+                .with(this.tracker ?: throw Exception("Tracker is not initialized"))
             promise.resolve(null)
         } catch (error: Exception) {
             promise.reject(error)
@@ -76,7 +76,7 @@ class PiwikProSdkModule(reactContext: ReactApplicationContext) : ReactContextBas
                 track.value(optionalArgs.getDouble("value").toFloat());
             }
 
-            track.with(this.tracker ?: throw Error("Tracker is not initialized"))
+            track.with(this.tracker ?: throw Exception("Tracker is not initialized"))
             promise.resolve(null)
         } catch (error: Exception) {
             promise.reject(error)
@@ -86,7 +86,7 @@ class PiwikProSdkModule(reactContext: ReactApplicationContext) : ReactContextBas
     @ReactMethod
     fun dispatch(promise: Promise) {
         try {
-            (this.tracker ?: throw Error("Tracker is not initialized")).dispatch()
+            (this.tracker ?: throw Exception("Tracker is not initialized")).dispatch()
             promise.resolve(null);
         } catch (error: Exception) {
             promise.reject(error)


### PR DESCRIPTION
Fixes Android app crashing when the the tracker is not initialised.

The issue was that the code was throwing an [`Error`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-error/) class, but only catching [`Exception`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-exception/) class throwables, which is not a superclass of `Error`. This resulted in the following kind of errors when attempting to track events before initialisation was completed:

```
Caused by java.lang.Error: Tracker is not initialized
       at com.reactnativepiwikprosdk.PiwikProSdkModule.trackEvent(PiwikProSdkModule.java:79)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:149)
```

Here we fix the issue by changing the type of class thrown when the tracker has not been initialised.