### PR TITLE
fix: android crash on missing class

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,5 +127,6 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   api 'pro.piwik.sdk:piwik-sdk:1.+'
+  implementation "com.google.android.gms:play-services-ads-identifier:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }


### PR DESCRIPTION
Fixes an issue where the upstream Android SDK depends on an ancient version of the [`com.google.android.gms:play-services-basement`](https://mvnrepository.com/artifact/com.google.android.gms/play-services-basement) library to include the class `com.google.android.gms.ads.identifier.AdvertisingIdClient` which has hence been moved to a separate library [com.google.android.gms:play-services-ads-identifier](https://mvnrepository.com/artifact/com.google.android.gms/play-services-ads-identifier).

The change caused crashes in certain situations where the application build updates the `play-services-basement` library, but not separately including the `play-services-ads-identifier` library.

Fixes #39 